### PR TITLE
let parseString also use class constant RIS_EOL instead of "\r\n"

### DIFF
--- a/src/LibRIS/RISReader.php
+++ b/src/LibRIS/RISReader.php
@@ -106,7 +106,7 @@ class RISReader {
    *  associative array of entry details. (See {@link LibRIS})
    */
   public function parseString($string) {
-    $contents = explode ("\r\n", $string);
+    $contents = explode (RISReader::RIS_EOL, $string);
     $this->parseArray($contents);
   }
 


### PR DESCRIPTION
The class function parseString should use RIS_EOL too.
